### PR TITLE
take amount and connection params

### DIFF
--- a/queries/config.yaml
+++ b/queries/config.yaml
@@ -32,7 +32,6 @@ queries:
       }
   - name: AlbumsArtistTracksGenreAll
     amount: 1000
-    rps: 400
     connections: 20
     query: |
       query AlbumsArtistTracksGenreAll {

--- a/queries/config.yaml
+++ b/queries/config.yaml
@@ -1,9 +1,9 @@
-url: http://localhost:8085/v1/graphql
+url: http://localhost:8080/v1/graphql
 headers:
   X-Hasura-Admin-Secret: my-secret
 queries:
   - name: SearchAlbumsWithArtist
-    duration: 10s
+    duration: 10
     rps: 400
     assert:
       results: 7
@@ -19,7 +19,7 @@ queries:
         }
       }
   - name: AlbumByPK
-    duration: 10s
+    duration: 20
     rps: 400
     assert:
       results: 1
@@ -31,8 +31,9 @@ queries:
         }
       }
   - name: AlbumsArtistTracksGenreAll
-    duration: 10s
+    amount: 1000
     rps: 400
+    connections: 20
     query: |
       query AlbumsArtistTracksGenreAll {
         albums {

--- a/queries/src/autocannon.js
+++ b/queries/src/autocannon.js
@@ -16,9 +16,11 @@ const makeOptions = (entry, config) => {
       url: config.url,
       method: 'POST',
       headers: config.headers,
-      duration: entry.duration,
+      duration: entry.duration || 10,
+      amount: entry.amount, // if both duration and amount are set, amount is preferred
       body: JSON.stringify({ query: entry.query, variables: entry.variables }),
       overallRate: entry.rps,
+      connections: entry.connections || 10,
       // setupClient: assertionHandler,
     },
   }
@@ -39,7 +41,7 @@ function runBenchmark({ entry, config, autocannonOpts }) {
     })
     autocannon.track(instance)
     instance.on('done', resolve)
-    if (entry.rps) console.log(entry.rps, 'req/s')
+    if (entry.rps) console.log(entry.rps, 'req/s (max; realized throughput may vary)')
   })
 }
 


### PR DESCRIPTION
The main idea is that if a query is heavy then it doesn't realize the number of requests that are expected. For example, if rps is 400 and duration is 10s then 4k requests are expected but may not be realized if query is heavy.

Using amount parameter in this case makes the benchmark more useful especially from a memory tracking perspective.