### PR TITLE
move headers inside connection_init payload

### DIFF
--- a/subscriptions/src/main.ts
+++ b/subscriptions/src/main.ts
@@ -186,7 +186,7 @@ class Connection {
     await socket.open()
     socket.sendPacked({
       type: GQL.CONNECTION_INIT,
-      payload: headers,
+      payload: { headers },
     })
     socket.sendPacked({
       id: String(id),


### PR DESCRIPTION
Move headers inside `connection_init` payload to be compatible with Apollo subscription specs